### PR TITLE
fix(chart): keep example comments out of unrelated schema descriptions

### DIFF
--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -111,7 +111,7 @@
       "description": "Gateway API HTTPRoute — an alternative to `ingress` for clusters using the\nGateway API. Renders one HTTPRoute pointing at the app service port. Named\n`httpRoute` (not `route`) to avoid confusion with the OpenShift Route kind.",
       "properties": {
         "additionalRules": {
-          "description": " - kromgo.example.com\nCustom rules prepended before the default rule (templated).",
+          "description": "Custom rules prepended before the default rule (templated).",
           "items": {
             "required": []
           },
@@ -145,7 +145,7 @@
           "type": "array"
         },
         "hostnames": {
-          "description": " - name: gateway\n   namespace: gateway\n   sectionName: https\nHostnames matched against the Host header (templated).",
+          "description": "Hostnames matched against the Host header (templated).",
           "items": {
             "required": []
           },

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -230,9 +230,11 @@ httpRoute:
   #  - name: gateway
   #    namespace: gateway
   #    sectionName: https
+
   # -- Hostnames matched against the Host header (templated).
   hostnames: []
   #  - kromgo.example.com
+
   # -- Custom rules prepended before the default rule (templated).
   additionalRules: []
   # -- Filters applied to the default rule.


### PR DESCRIPTION
Same fix as home-operations/gatus-sidecar#170: helm-schema attaches a commented example block to the *next* key's description in `values.schema.json`, which surfaces as hover docs in editors consuming the schema. Two instances here:

- the `httpRoute.parentRefs` example leaked into `httpRoute.hostnames`
- the `httpRoute.hostnames` example leaked into `httpRoute.additionalRules`

A blank line after each example block stops helm-schema from carrying it forward. Verified with a schema-wide scan (no leaked descriptions remain); chart README and config.schema.json are unchanged, `helm unittest` 17/17, `helm lint` clean.
